### PR TITLE
Add mysql install step to macOS setup instructions

### DIFF
--- a/memberportal/README.md
+++ b/memberportal/README.md
@@ -41,11 +41,17 @@ You should see `(venv) $` at your command prompt, letting you know that you’re
 deactivate
 ```
 
-#####
-Notes: if you're running macOS Big Sur (and/or an Apple Silicon Mac), you may need to run this command to install the dependencies:
+#### Notes
+
+If you're running macOS Big Sur (and/or an Apple Silicon Mac), you may need to run this command to install the dependencies:
 ```
 CFLAGS='-I/usr/local/opt/zlib/include -L/usr/local/opt/zlib/lib' pip3 install -r requirements.txt
 ```
+
+You may need to install `mysql` if you don't have it already. It's required when installing the `mysqlclient` Python dependency:
+```
+ brew install mysql
+ ```
 
 ## Windows
 Please follow the instructions below to setup dev environment in Windows (tested in Windows 7 & 10).


### PR DESCRIPTION
Hey there, just getting the backend running locally and had to install mysql for the pip install to work. Not sure if universal but some updated docs in case anyone else hits it.