### PR TITLE
Fix broken build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,8 @@ LABEL description="Base Dockerfile for the MemberMatters software."
 VOLUME /usr/src/data/
 VOLUME /usr/src/logs/
 
-RUN mkdir -p /usr/src/app/frontend && mkdir /usr/src/logs && mkdir /usr/src/data
-ADD memberportal/requirements.txt /usr/src/app/memberportal/requirements.txt
+RUN mkdir -p /usr/src/app/frontend && mkdir -p /usr/src/logs && mkdir -p /usr/src/data
+COPY memberportal/requirements.txt /usr/src/app/memberportal/requirements.txt
 
 RUN apt-get update && apt-get install -y nginx curl build-essential gcc make
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -29,13 +29,13 @@ RUN nvm use --delete-prefix v${NODE_VERSION} --silent
 
 # Install node deps
 WORKDIR /usr/src/app/frontend/
-ADD frontend/package* /usr/src/app/frontend/
+COPY frontend/package* /usr/src/app/frontend/
 RUN npm ci
 
-ADD frontend /usr/src/app/frontend
-ADD memberportal /usr/src/app/memberportal
-ADD docker /usr/src/app/docker
-ADD package.json /usr/src/app/package.json
+COPY frontend /usr/src/app/frontend
+COPY memberportal /usr/src/app/memberportal
+COPY docker /usr/src/app/docker
+COPY package.json /usr/src/app/package.json
 
 # Build our frontend
 WORKDIR /usr/src/app/frontend/
@@ -49,7 +49,7 @@ WORKDIR /usr/src/app/memberportal/
 RUN python3 manage.py collectstatic --noinput
 
 # Copy over the nginx config and requirement files
-ADD docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/nginx.conf /etc/nginx/nginx.conf
 
 # Expose the port and run the app
 EXPOSE 8000

--- a/memberportal/requirements.txt
+++ b/memberportal/requirements.txt
@@ -20,3 +20,4 @@ git+https://github.com/mailchimp/mailchimp-marketing-python.git
 channels~=3.0.4
 zeroconf~=0.38.3
 postmarker~=1.0
+python_http_client~=3.3.7


### PR DESCRIPTION
:wave: Hi there!  I was having trouble getting the latest release, v2.8.0 to run due to a missing python dependency, with the v2.8.0 image that is in dockerhub (`No module named 'python_http_client'`).

I also ran into some trouble building the docker image on my own machine, which died with this error:
```
mkdir: cannot create directory ‘/usr/src/logs’: File exists
The command '/bin/sh -c mkdir -p /usr/src/app/frontend && mkdir /usr/src/logs && mkdir /usr/src/data' returned a non-zero code: 1
```

This fixes both of these problems for me.