### PR TITLE
Add support for Prometheus metrics endpoint

### DIFF
--- a/memberportal/membermatters/settings.py
+++ b/memberportal/membermatters/settings.py
@@ -48,6 +48,7 @@ if os.environ.get("PORTAL_ENV") == "Production":
 INSTALLED_APPS = [
     "constance",
     "constance.backends.database",
+    "django_prometheus",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -71,6 +72,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -81,6 +83,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "membermatters.middleware.Sentry",
     "membermatters.middleware.ForceCsrfCookieMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "membermatters.urls"

--- a/memberportal/membermatters/urls.py
+++ b/memberportal/membermatters/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     path("api/admin/", include("api_admin_tools.urls")),
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
+    path('', include('django_prometheus.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
This PR adds in a `/metrics` endpoint to the back-end, giving us an insight into how well the application is performing via https://github.com/korfuri/django-prometheus

The initial code in this PR only enables the basic metrics, however it is possible to instrument the database and cache connections, as well as showing how often models are created/updated/deleted etc. over time. 

The same could be achieved for the frontend in future using something like https://github.com/siimon/prom-client