### PR TITLE
Enable canvas induction via a feature flag

### DIFF
--- a/memberportal/api_billing/views.py
+++ b/memberportal/api_billing/views.py
@@ -19,6 +19,7 @@ from sentry_sdk import capture_exception
 
 logger = logging.getLogger("app")
 
+
 class StripeAPIView(APIView):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/memberportal/api_billing/views.py
+++ b/memberportal/api_billing/views.py
@@ -19,7 +19,6 @@ from sentry_sdk import capture_exception
 
 logger = logging.getLogger("app")
 
-
 class StripeAPIView(APIView):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/memberportal/membermatters/constance_config.py
+++ b/memberportal/membermatters/constance_config.py
@@ -233,10 +233,10 @@ CONSTANCE_CONFIG = {
         "PLEASE_CHANGE_ME",
         "The API key used to send email with Postmark.",
     ),
-    # Induction 
+    # Induction
     "CANVAS_INDUCTION_ENABLED": (
-            True,
-            "Whether induction is performed via the Canvas platform or not",
+        True,
+        "Whether induction is performed via the Canvas platform or not",
     ),
     "INDUCTION_ENROL_LINK": (
         "",

--- a/memberportal/membermatters/constance_config.py
+++ b/memberportal/membermatters/constance_config.py
@@ -233,6 +233,11 @@ CONSTANCE_CONFIG = {
         "PLEASE_CHANGE_ME",
         "The API key used to send email with Postmark.",
     ),
+    # Induction 
+    "CANVAS_INDUCTION_ENABLED": (
+            True,
+            "Whether induction is performed via the Canvas platform or not",
+    ),
     "INDUCTION_ENROL_LINK": (
         "",
         "The link that a member can use to enrol into an induction.",
@@ -351,7 +356,10 @@ CONSTANCE_CONFIG_FIELDSETS = OrderedDict(
         ),
         (
             "Canvas (LMS) Integration",
-            ("CANVAS_API_TOKEN",),
+            (
+                "CANVAS_API_TOKEN",
+                "CANVAS_INDUCTION_ENABLED",
+            ),
         ),
         ("Postmark (EMAIL) Integration", ("POSTMARK_API_KEY",)),
         (

--- a/memberportal/profile/models.py
+++ b/memberportal/profile/models.py
@@ -547,7 +547,8 @@ class Profile(models.Model):
         if config.MAX_INDUCTION_DAYS > 0 and (
             last_inducted is None or last_inducted < furthest_previous_date
         ):
-            required_steps.append("induction")
+            if config.CANVAS_INDUCTION_ENABLED is True:
+                required_steps.append("induction")
 
         # check if they have an RFID card assigned
         if not self.rfid:


### PR DESCRIPTION
An initial attempt to resolve #186, this PR adds a new config flag in Constance to enable inductions via Canvas and sets it to `True` by default to ensure that behaviour remains the same as the current way of working.

Setting it to `False` allows Maker/Hackspaces that do not have courses setup in Canvas to skip this step but still allow members to become active within the platform.

This almost certainly needs more work and some better testing as I'm hitting an error right at the end about an existing member profile:
![image](https://user-images.githubusercontent.com/262545/187864024-44e6f914-b4fa-4a69-99b2-21227710bf1b.png)
