### PR TITLE
Add a view to get member details by screen name

### DIFF
--- a/memberportal/api_admin_tools/urls.py
+++ b/memberportal/api_admin_tools/urls.py
@@ -5,11 +5,11 @@ from . import views
 
 urlpatterns = [
     path("api/admin/members/", views.GetMembers.as_view(), name="GetMembers"),
-    path(
-        "api/admin/member/<str:screen_name>/",
-        views.MemberProfileByName.as_view(),
-        name="MemberProfileByName",
-    ),
+    #    path(
+    #        "api/admin/member/<str:screen_name>/",
+    #        views.MemberProfileByName.as_view(),
+    #        name="MemberProfileByName",
+    #    ),
     path(
         "api/admin/members/<int:member_id>/state/<str:state>/",
         views.MemberState.as_view(),

--- a/memberportal/api_admin_tools/urls.py
+++ b/memberportal/api_admin_tools/urls.py
@@ -6,6 +6,11 @@ from . import views
 urlpatterns = [
     path("api/admin/members/", views.GetMembers.as_view(), name="GetMembers"),
     path(
+        "api/admin/member/<str:screen_name>/",
+        views.MemberProfileByName.as_view(),
+        name="MemberProfileByName",
+    ),
+    path(
         "api/admin/members/<int:member_id>/state/<str:state>/",
         views.MemberState.as_view(),
         name="MemberState",

--- a/memberportal/api_admin_tools/views.py
+++ b/memberportal/api_admin_tools/views.py
@@ -1,4 +1,4 @@
-from profile.models import User, UserEventLog
+from profile.models import User, UserEventLog, Profile
 from access.models import DoorLog, InterlockLog
 from access import models
 from .models import MemberTier, PaymentPlan
@@ -377,6 +377,26 @@ class MemberProfile(APIView):
                 door.sync()
 
         return Response()
+
+
+class MemberProfileByName(APIView):
+    """
+    get: This method gets a specific member's profile.
+    """
+
+    permission_classes = (permissions.IsAdminUser,)
+
+    def get(self, request, screen_name=None):
+        member = {}
+        if not screen_name:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        member_object = Profile.objects.get(screen_name=screen_name)
+        member["screen_name"] = member_object.screen_name
+        member["rfid_token"] = member_object.rfid
+        member["email_address"] = member_object.user.email
+
+        return Response(member)
 
 
 class MemberTiers(StripeAPIView):


### PR DESCRIPTION
Fixes #211 

This code provides a new endpoint `/api/admin/member/<str:screen_name>` that allows us to look up an RFID tag (and whatever other information we choose to add in future!) based on a screen name.

The assumption is that the screen name will the username on the calling platform, and as a result we will be able to associate RFID tags (and therefore memberbucks) across disparate systems.

Example:

![image](https://github.com/membermatters/MemberMatters/assets/262545/204df84d-ce39-4ff5-b6f1-8d82b222fa8e)
