### PR TITLE
Fix #232 by making 'tempalte_name' argument optional

### DIFF
--- a/memberportal/services/emails.py
+++ b/memberportal/services/emails.py
@@ -12,7 +12,7 @@ def send_single_email(
     to_email: object,
     subject: object,
     template_vars: object,
-    template_name,
+    template_name=None,
     reply_to=None,
     user: object | None = None,
 ) -> object:


### PR DESCRIPTION
Fixes #232 by making the send_single_email() functions 'template_name' argument optional