### PR TITLE
Update SpaceAPI to return integer version number

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3

--- a/memberportal/api_admin_tools/views.py
+++ b/memberportal/api_admin_tools/views.py
@@ -726,9 +726,11 @@ class MemberLogs(APIView):
                     "totalTime": interlock_log.total_time,
                     "totalCost": (interlock_log.total_cost or 0) / 100,
                     "status": status,
-                    "userEnded": interlock_log.user_ended.get_full_name()
-                    if interlock_log.user_ended
-                    else None,
+                    "userEnded": (
+                        interlock_log.user_ended.get_full_name()
+                        if interlock_log.user_ended
+                        else None
+                    ),
                 }
             )
 

--- a/memberportal/api_general/views.py
+++ b/memberportal/api_general/views.py
@@ -394,14 +394,14 @@ class ProfileDetail(generics.GenericAPIView):
                         "expiry": p.stripe_card_expiry,
                     },
                 },
-                "membershipPlan": p.membership_plan.get_object()
-                if p.membership_plan
-                else None,
-                "membershipTier": p.membership_plan.member_tier.get_object()
-                if p.membership_plan
-                else None
-                if p.membership_plan
-                else None,
+                "membershipPlan": (
+                    p.membership_plan.get_object() if p.membership_plan else None
+                ),
+                "membershipTier": (
+                    p.membership_plan.member_tier.get_object()
+                    if p.membership_plan
+                    else None if p.membership_plan else None
+                ),
                 "subscriptionState": p.subscription_status,
             },
             "permissions": {"admin": user.is_admin},

--- a/memberportal/api_spacedirectory/views.py
+++ b/memberportal/api_spacedirectory/views.py
@@ -103,7 +103,7 @@ class SpaceDirectoryStatus(APIView):
                 "open": config.SPACE_DIRECTORY_ICON_OPEN,
                 "closed": config.SPACE_DIRECTORY_ICON_CLOSED,
             }
-            spaceapi["api_compatibility"] = ["0.14"]
+            spaceapi["api_compatibility"] = ["14"]
 
             ## Add the sensor data to the main body of the schema
             spaceapi["sensors"] = sensor_data

--- a/memberportal/membermatters/urls.py
+++ b/memberportal/membermatters/urls.py
@@ -1,5 +1,6 @@
 """membermatters URL Configuration
 """
+
 import os
 import django.db.utils
 from django.contrib import admin

--- a/memberportal/membermatters/wsgi.py
+++ b/memberportal/membermatters/wsgi.py
@@ -3,6 +3,7 @@ exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see 
 https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/ 
 """
+
 import os
 from django.core.wsgi import get_wsgi_application
 import logging, sys

--- a/memberportal/profile/models.py
+++ b/memberportal/profile/models.py
@@ -538,19 +538,23 @@ class Profile(models.Model):
             "rfid": self.rfid,
             "memberBucks": {
                 "balance": self.memberbucks_balance,
-                "lastPurchase": self.last_memberbucks_purchase.strftime(
-                    "%m/%d/%Y, %H:%M:%S"
-                )
-                if self.last_memberbucks_purchase
-                else None,
+                "lastPurchase": (
+                    self.last_memberbucks_purchase.strftime("%m/%d/%Y, %H:%M:%S")
+                    if self.last_memberbucks_purchase
+                    else None
+                ),
             },
             "updateProfileRequired": self.must_update_profile,
-            "lastSeen": self.last_seen.strftime("%m/%d/%Y, %H:%M:%S")
-            if self.last_seen
-            else None,
-            "lastInduction": self.last_induction.strftime("%m/%d/%Y, %H:%M:%S")
-            if self.last_induction
-            else None,
+            "lastSeen": (
+                self.last_seen.strftime("%m/%d/%Y, %H:%M:%S")
+                if self.last_seen
+                else None
+            ),
+            "lastInduction": (
+                self.last_induction.strftime("%m/%d/%Y, %H:%M:%S")
+                if self.last_induction
+                else None
+            ),
             "stripe": {
                 "cardExpiry": self.stripe_card_expiry,
                 "last4": self.stripe_card_last_digits,


### PR DESCRIPTION
Small PR to update the `api_compatibility` field to use an integer version number, consistent with a recent change in the v14 schema definition.

See also https://github.com/SpaceApi/directory/pull/250#issuecomment-1922433374