### PR TITLE
SpaceAPI follows schema for sensor values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.6.2] - 2024-02-02
+
+### Fixed
+
+- SpaceAPI return type for version number (thanks @rechner)
+
+### Added
+
+- New OIDC scope called `membershipinfo` and extra claims
+- New GitHub Actions for checks and docker build on every PR
+
+### Changed
+
+- Cleaned up some old code/models
+- Tidied up redundant staff/admin attributes
+
 ## [v3.6.1] - 2024-01-20
 
 ### Fixed
@@ -543,11 +559,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First run detection and fixture loading.
 - Added a handful of missing translation definitions.
 - Corner/border formatting with credit card component.
-- https://github.com/membermatters/MemberMatters/issues/90
-- https://github.com/membermatters/MemberMatters/issues/91
-- https://github.com/membermatters/MemberMatters/issues/92
-- https://github.com/membermatters/MemberMatters/issues/93
-- https://github.com/membermatters/MemberMatters/issues/101
+- <https://github.com/membermatters/MemberMatters/issues/90>
+- <https://github.com/membermatters/MemberMatters/issues/91>
+- <https://github.com/membermatters/MemberMatters/issues/92>
+- <https://github.com/membermatters/MemberMatters/issues/93>
+- <https://github.com/membermatters/MemberMatters/issues/101>
 
 ## Versions prior to v2.1.0 don't have changelog entries
 

--- a/memberportal/api_spacedirectory/views.py
+++ b/memberportal/api_spacedirectory/views.py
@@ -60,7 +60,7 @@ class SpaceDirectoryStatus(APIView):
                 ## Setup the basic details
                 sensor_details = {
                     "name": sensor.name,
-                    "description": sensor.description,
+                    "description": sensor.description or "",
                     "location": sensor.location,
                 }
 
@@ -83,11 +83,11 @@ class SpaceDirectoryStatus(APIView):
                 signout_date=None
             ).order_by("-signin_date")
 
-            sensor_data["total_member_count"] = {"value": spaceapi_user_count}
+            sensor_data["total_member_count"] = [{"value": spaceapi_user_count}]
 
-            sensor_data["people_now_present"] = {
-                "value": spaceapi_members_on_site.count()
-            }
+            sensor_data["people_now_present"] = [
+                {"value": spaceapi_members_on_site.count()}
+            ]
 
             # Is the camera array empty? If not, add them
             if not config.SPACE_DIRECTORY_CAMS:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "membermatters",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "devDependencies": {
     "eslint-webpack-plugin": "^3.1.1",
     "husky": "^6.0.0",

--- a/src-frontend/package.json
+++ b/src-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "The MemberMatters frontend",
   "productName": "MemberMatters",
   "author": "Jaimyn Mayer <github@jaimyn.dev>",


### PR DESCRIPTION
Small fix to format sensor values as it is expected by [the SpaceAPI schema specification](https://spaceapi.io/docs/#schema-key-state-open).  

Spot-checked with a few of the different sensor types, here is an example output which passes the [SpaceAPI validator](https://spaceapi.io/validator/):

<details>
<summary>Space status example</summary>

```json
{
    "space": "MemberMatters",
    "logo": "https://brisbanemaker.space/wp-content/uploads/2021/10/BMS-Logo-ONLY.png",
    "url": "https://membermatters.org",
    "contact": {
        "email": "notset@example.com",
        "twitter": "",
        "phone": "",
        "facebook": ""
    },
    "spacefed": {
        "spacenet": false,
        "spacesaml": false,
        "spacephone": false
    },
    "projects": [],
    "issue_report_channels": [
        "email"
    ],
    "state": {
        "open": true,
        "message": "The space is open!",
        "lastchange": 1708996661.442005
    },
    "icon": {
        "open": "",
        "closed": ""
    },
    "api_compatibility": [
        "14"
    ],
    "sensors": {
        "beverage_supply": [
            {
                "name": "cans_of_coke",
                "description": "",
                "location": "fridge",
                "value": 20.0,
                "unit": "btl"
            }
        ],
        "total_member_count": [
            {
                "value": 0
            }
        ],
        "people_now_present": [
            {
                "value": 0
            }
        ]
    },
    "location": {
        "address": "123 Setme St",
        "lat": 0.0,
        "lon": 0.0
    }
}
```

</details>