### PR TITLE
Feature/change timezone

### DIFF
--- a/docs/POST_INSTALL_STEPS.md
+++ b/docs/POST_INSTALL_STEPS.md
@@ -72,7 +72,11 @@ However, as noted below, currencies will use a hardcoded value set by a configur
 
 > NOTE: the `SITE_LOCALE_CURRENCY` option is what determines how the currency is displayed. This is "hardcoded" as a 
 > config option to prevent a currency/billing amount being displayed incorrectly. If your locale isn't directly 
-> supported, please open an issue or check below as your currency may already be supported under a different locale.
+> supported, please open an issue or check below as your currency may already be supported under a different locale.o
+
+> NOTE: If you want to set the *server* timezone and language, export `MM_TIME_ZONE=<your area>/<your country>` and 
+> `MM_LANGAUGE_CODE=<your-language-code>` before launching the server component.  If you do not set these variables,
+> the server logs will default to `Australia/Brisbane` as the timezone and `en-au` as the default language.
  
 #### Locale Options
 * `en-AU` - full translation available, currency format `$12.50`.

--- a/memberportal/membermatters/settings.py
+++ b/memberportal/membermatters/settings.py
@@ -330,9 +330,9 @@ SIMPLE_JWT = {
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/
 
-LANGUAGE_CODE = "en-au"
+LANGUAGE_CODE = os.getenv("MM_LANGUAGE_CODE", "en-au")
 
-TIME_ZONE = "Australia/Brisbane"
+TIME_ZONE = os.getenv("MM_TIME_ZONE", "Australia/Brisbane")
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True


### PR DESCRIPTION
At present, the timezone defaults to `Australia/Brisbane` and as a result all our server logs are out by hours compared with our own timezone.  The language is also set to `en-au`.

This PR keeps the original values as defaults, but allows configuring both values via environment variables for those of us who aren't fortunate enough to live in Australia! :stuck_out_tongue: 