### PR TITLE
V3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.7.1] - 2024-08-23
+
+### Added
+
+- Added support for specifying system timezone with MM_TIME_ZONE env var
+- Added support for specifying system locale with MM_LANGAUGE_CODE env var
+
+### Updated
+
+- README.md to include [Pawprint Prototyping](https://pawprintprototyping.org/)
 
 ## [v3.7.0] - 2024-08-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "membermatters",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "devDependencies": {
     "eslint-webpack-plugin": "^3.1.1",
     "husky": "^6.0.0",

--- a/src-frontend/package.json
+++ b/src-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "The MemberMatters frontend",
   "productName": "MemberMatters",
   "author": "Jaimyn Mayer <github@jaimyn.dev>",


### PR DESCRIPTION
## [v3.7.1] - 2024-08-23

### Added

- Added support for specifying system timezone with MM_TIME_ZONE env var
- Added support for specifying system locale with MM_LANGAUGE_CODE env var

### Updated

- README.md to include [Pawprint Prototyping](https://pawprintprototyping.org/)