### PR TITLE
Add backend import/export functionality

### DIFF
--- a/memberportal/membermatters/settings.py
+++ b/memberportal/membermatters/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     "rest_framework_api_key",
     "django_celery_results",
     "django_celery_beat",
+    "import_export",
 ]
 
 MIDDLEWARE = [

--- a/memberportal/profile/admin.py
+++ b/memberportal/profile/admin.py
@@ -100,41 +100,6 @@ class UserResource(resources.ModelResource):
         )
 
 
-class ProfileResource(resources.ModelResource):
-    def before_import_row(self, row, **kwargs):
-        row["user"] = (
-            User.objects.get_or_create(
-                email=email,
-                defaults={
-                    "email": email,
-                    "email_verified": email_verified,
-                    "staff": staff,
-                    "admin": admin,
-                },
-            )
-        )[0]
-        print("Got user {}".format(row["user"]))
-        if row["user"].profile is None:
-            print(
-                "Creating a profile for user {} result: {}".format(
-                    row["user"].email, Profile.objects.create(user=row["user"])
-                )
-            )
-
-    class Meta:
-        model = Profile
-        import_id_fields = ["user__email"]
-        fields = (
-            "user__email",
-            "user__staff",
-            "user__admin",
-            "screen_name",
-            "first_name",
-            "last_name",
-            "rfid",
-        )
-
-
 @admin.register(User)
 class AdminLogAdmin(ImportExportModelAdmin, admin.ModelAdmin):
     resource_class = UserResource

--- a/memberportal/profile/admin.py
+++ b/memberportal/profile/admin.py
@@ -5,21 +5,30 @@ from import_export import resources, fields
 from import_export.widgets import ForeignKeyWidget
 from django.utils import timezone
 
+
 class UserResource(resources.ModelResource):
     first_name = fields.Field(
-        column_name="first_name", attribute="first_name", widget=ForeignKeyWidget(Profile, "first_name")
+        column_name="first_name",
+        attribute="first_name",
+        widget=ForeignKeyWidget(Profile, "first_name"),
     )
     last_name = fields.Field(
-        column_name="last_name", attribute="last_name", widget=ForeignKeyWidget(Profile, "last_name")
+        column_name="last_name",
+        attribute="last_name",
+        widget=ForeignKeyWidget(Profile, "last_name"),
     )
     screen_name = fields.Field(
-        column_name="screen_name", attribute="screen_name", widget=ForeignKeyWidget(Profile, "screen_name")
+        column_name="screen_name",
+        attribute="screen_name",
+        widget=ForeignKeyWidget(Profile, "screen_name"),
     )
     rfid = fields.Field(
         column_name="rfid", attribute="rfid", widget=ForeignKeyWidget(Profile, "rfid")
     )
     state = fields.Field(
-        column_name="state", attribute="state", widget=ForeignKeyWidget(Profile, "state")
+        column_name="state",
+        attribute="state",
+        widget=ForeignKeyWidget(Profile, "state"),
     )
 
     def dehydrate_first_name(self, user):
@@ -27,21 +36,25 @@ class UserResource(resources.ModelResource):
             return user.profile.first_name
         except Exception:
             return ""
+
     def dehydrate_last_name(self, user):
         try:
             return user.profile.last_name
         except Exception:
             return ""
+
     def dehydrate_screen_name_name(self, user):
         try:
             return user.profile.screen_name
         except Exception:
             return ""
+
     def dehydrate_rfid(self, user):
         try:
             return user.profile.rfid
         except Exception:
             return None
+
     def dehydrate_state(self, user):
         try:
             return user.profile.state
@@ -56,7 +69,7 @@ class UserResource(resources.ModelResource):
                 "email_verified": True,
                 "admin": row["admin"],
                 "staff": row["staff"],
-            }
+            },
         )
 
         # new User needs a Profile
@@ -71,34 +84,55 @@ class UserResource(resources.ModelResource):
             )
 
     def skip_row(self, instance, original, row, import_validation_errors):
-        return (row["email"] == "default@example.com")
+        return row["email"] == "default@example.com"
 
     class Meta:
         model = User
         import_id_fields = ["email"]
-        fields = ('email', 'staff', 'admin', 'first_name', 'last_name', 'screen_name', 'rfid')
+        fields = (
+            "email",
+            "staff",
+            "admin",
+            "first_name",
+            "last_name",
+            "screen_name",
+            "rfid",
+        )
+
 
 class ProfileResource(resources.ModelResource):
     def before_import_row(self, row, **kwargs):
-        row["user"] = (User.objects.get_or_create(
-            email=email,
-            defaults={
-                "email": email,
-                "email_verified": email_verified,
-                "staff": staff,
-                "admin": admin,
-            }
-            ))[0]
+        row["user"] = (
+            User.objects.get_or_create(
+                email=email,
+                defaults={
+                    "email": email,
+                    "email_verified": email_verified,
+                    "staff": staff,
+                    "admin": admin,
+                },
+            )
+        )[0]
         print("Got user {}".format(row["user"]))
         if row["user"].profile is None:
-            print("Creating a profile for user {} result: {}".format(row["user"].email, Profile.objects.create(
-                user=row["user"]
-            )))
+            print(
+                "Creating a profile for user {} result: {}".format(
+                    row["user"].email, Profile.objects.create(user=row["user"])
+                )
+            )
 
     class Meta:
         model = Profile
         import_id_fields = ["user__email"]
-        fields = ('user__email', 'user__staff', 'user__admin', 'screen_name', 'first_name', 'last_name', 'rfid')
+        fields = (
+            "user__email",
+            "user__staff",
+            "user__admin",
+            "screen_name",
+            "first_name",
+            "last_name",
+            "rfid",
+        )
 
 
 @admin.register(User)

--- a/memberportal/profile/admin.py
+++ b/memberportal/profile/admin.py
@@ -1,14 +1,133 @@
 from django.contrib import admin
 from .models import *
+from import_export.admin import ImportExportModelAdmin
+from import_export import resources, fields
+from import_export.widgets import ForeignKeyWidget
+
+
+class MemberResource(resources.ModelResource):
+    email = fields.Field(
+        column_name="email", attribute="email", widget=ForeignKeyWidget(User, "email")
+    )
+    email_verified = fields.Field(
+        column_name="email_verified",
+        attribute="email_verified",
+        widget=ForeignKeyWidget(User, "email_verified"),
+    )
+    staff = fields.Field(
+        column_name="staff", attribute="staff", widget=ForeignKeyWidget(User, "staff")
+    )
+    admin = fields.Field(
+        column_name="admin", attribute="admin", widget=ForeignKeyWidget(User, "admin")
+    )
+    user = fields.Field(attribute="id", widget=ForeignKeyWidget(User, "id"))
+
+    def before_import_row(self, row, **kwargs):
+        email = row["email"]
+        email_verified = row["email_verified"]
+        staff = row["staff"]
+        admin = row["admin"]
+        row["user"] = User.objects.get_or_create(
+            email=email,
+            defaults={
+                "email": email,
+                "email_verified": email_verified,
+                "staff": staff,
+                "admin": admin,
+            },
+        ).id
+
+    def dehydrate_email(self, profile):
+        try:
+            return profile.user.email
+        except Exception:
+            return "NADA"
+
+    def dehydrate_email_verified(self, profile):
+        try:
+            return profile.user.email_verified
+        except Exception:
+            return "False"
+
+    def dehydrate_staff(self, profile):
+        try:
+            return profile.user.staff
+        except Exception:
+            return "False"
+
+    def dehydrate_admin(self, profile):
+        try:
+            return profile.user.admin
+        except Exception:
+            return "False"
+
+    class Meta:
+        model = Profile
+        import_id_fields = ("user",)
+        fields = (
+            "email",
+            "email_verified",
+            "staff",
+            "admin",
+            "digital_id_token",
+            "digital_id_token_expire",
+            "created",
+            "modified",
+            "screen_name",
+            "first_name",
+            "last_name",
+            "phone_regex",
+            "phone",
+            "state",
+            "vehicle_registration_plate",
+            "membership_plan",
+            "rfid",
+            "doors",
+            "interlocks",
+            "memberbucks_balance",
+            "last_memberbucks_purchase",
+            "must_update_profile",
+            "exclude_from_email_export",
+            "last_seen",
+            "last_induction",
+            "stripe_customer_id",
+            "stripe_card_expiry",
+            "stripe_card_last_digits",
+            "stripe_payment_method_id",
+            "stripe_subscription_id",
+            "subscription_status",
+            "subscription_first_created",
+        )
+
+
+# class UserResource(resources.ModelResource):
+#     class Meta:
+#         model = User
+#         fields = ('id', 'email', 'email_verified', 'staff', 'admin',)
+
+# class ProfileResource(resources.ModelResource):
+#     class Meta:
+#         model = Profile
+#         fields = ('id', 'user', 'digital_id_token', 'digital_id_token_expire', 'created', 'modified',
+#         'screen_name', 'first_name', 'last_name', 'phone_regex', 'phone', 'state', 'vehicle_registration_plate',
+#         'membership_plan', 'rfid', 'doors', 'interlocks', 'memberbucks_balance', 'last_memberbucks_purchase',
+#         'must_update_profile', 'exclude_from_email_export', 'last_seen', 'last_induction', 'stripe_customer_id',
+#         'stripe_card_expiry', 'stripe_card_last_digits', 'stripe_payment_method_id', 'stripe_subscription_id',
+#         'subscription_status', 'subscription_first_created',)
 
 
 @admin.register(User)
 class AdminLogAdmin(admin.ModelAdmin):
+    # resource_class = UserResource
+    # resource_class = MemberResource
+    # resource_classes = [UserResource, ProfileResource]
     pass
 
 
 @admin.register(Profile)
-class ProfileAdmin(admin.ModelAdmin):
+class ProfileAdmin(ImportExportModelAdmin, admin.ModelAdmin):
+    # resource_class = ProfileResource
+    resource_class = MemberResource
     readonly_fields = ("created", "subscription_first_created")
     pass
 

--- a/memberportal/profile/models.py
+++ b/memberportal/profile/models.py
@@ -176,7 +176,10 @@ class User(ExportModelOperationsMixin("user"), AbstractBaseUser, PermissionsMixi
     objects = UserManager()
 
     def __str__(self):
-        return f"{self.get_full_name()} ({self.profile.screen_name}) - {self.email}"
+        try:
+            return f"{self.get_full_name()} ({self.profile.screen_name}) - {self.email}"
+        except:
+            return f"(NO PROFILE) - {self.email}"
 
     def get_short_name(self):
         return self.profile.get_short_name()

--- a/memberportal/requirements.txt
+++ b/memberportal/requirements.txt
@@ -7,8 +7,8 @@ django-picklefield~=3.2
 django-cors-headers~=4.3.1
 black==24.4.2
 pre-commit==3.7.1
-djangorestframework~=3.15.1
-djangorestframework-simplejwt>=5.3.1
+djangorestframework==3.15.1
+djangorestframework-simplejwt==5.3.1
 django-csp~=3.8
 sentry-sdk==2.3.1
 mysqlclient~=2.2.4
@@ -31,3 +31,4 @@ django-oidc-provider~=0.8.2
 djangorestframework-api-key~=3.0.0
 prometheus-client~=0.20.0
 python-dateutil~=2.9.0
+django-import-export~=3.3.9


### PR DESCRIPTION
Working on a start to #255.  This will enable hackerspaces that already have some sort of established (albeit minimal) member management to programmatically create MemberMatters users (via CSV for example).  Combined with the export functionality this can be used for disaster recovery, but it is *not* a replacement for a database backup as profiles can only be minimally populated.