### PR TITLE
20250813 Swedish language spelling & Readme update with makerspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ Feel free to add your organisation to this list (via a pull request) if you're a
 * [Make Monmouth](https://www.makemonmouth.co.uk/) (November 2023) - A community makerspace based in Monmouth, Wales, UK.
 * [SparkCC](https://www.sparkcc.org) (September 2021) - A community of makers on the NSW Central Coast based in Palmdale, NSW, Australia.
 * [Pawprint Prototyping](https://pawprintprototyping.org/) (October 2021) - non-profit hackerspace in Santa Clara, California, USA.  A lot of us are also animals on the internet 🐾.
+* [MakersLink](https://makerslink.se) - (August 2025) A community makerspace based in Linköping, Sweden.

--- a/src-frontend/src/i18n/sv-SE/index.ts
+++ b/src-frontend/src/i18n/sv-SE/index.ts
@@ -13,16 +13,16 @@ export default {
     register: 'Registrering',
     registerSuccess: 'Lyckade registrering',
     manageTiers: 'Medlemskapsnivåer',
-    manageTier: 'Hantera Medlemskaps',
+    manageTier: 'Hantera Medlemskap',
     managePlan: 'Hantera Betalningar',
     verifyEmail: 'Verifiera din email för att fortsätta',
 
     meetings: 'Möten',
     members: 'Medlemmar', // for routes
-    manageMember: 'hantera Medlem',
+    manageMember: 'Hantera Medlem',
     doors: 'Dörrar',
     manageDoor: 'Hantera Dörrar',
-    manageInterlock: 'Hantera  Lås',
+    manageInterlock: 'Hantera Lås',
     manageDevice: 'Hantera Enheter',
     interlocks: 'Lås',
     devices: 'Enheter',
@@ -84,7 +84,7 @@ export default {
     401: ' Du måste vara inloggad för att komma åt denna sida. (Error 401)',
     403: " Du saknar rättigheter för att komma åt denna sida. (Error 403)",
     '403MemberOnly':
-      'Du måste vara ha ett aktivt medkelsmakp för att komma åt denna sida. (Error 403)',
+      'Du måste vara ha ett aktivt medlemskap för att komma åt denna sida. (Error 403)',
     404: ' Denna sida kan inte hittas. (Error 404)',
     500: ' Det uppstod ett fel på servern. Försök igen senare. (Error 500)',
     501: " Denna funktion är ännu inte implementerad. (Error 501)",


### PR DESCRIPTION
[MakersLink in Linköping](https://makerslink.se), [Sweden](https://en.wikipedia.org/wiki/Sweden), has now started using MemberMatters to manage the makers memberships.

Made a note in readme about Makerslink

Also corrected some minor spelling mistakes in the sv-SE translation