### PR TITLE
Enable signup without entering RFID card

### DIFF
--- a/docs/POST_INSTALL_STEPS.md
+++ b/docs/POST_INSTALL_STEPS.md
@@ -97,7 +97,11 @@ However, as noted below, currencies will use a hardcoded value set by a configur
   * "MAX_INDUCTION_DAYS" -  Maximum number of days since they were inducted before they require another induction. Set 
     to `0` to disable induction requirement.
   * "MIN_INDUCTION_SCORE" - The minimum score considered a "pass" for the induction course.
-  * "REQUIRE_ACCESS_CARD" - Require the member to submit their RFID access card number during signup.
+  * "REQUIRE_ACCESS_CARD" - Require the member to have an RFID access card assigned before completing signup. Set to
+    `False` to skip the access card step entirely.
+  * "MEMBER_CAN_ENTER_ACCESS_CARD" - Allow members to enter their own RFID card number during signup. Set to `False`
+    to require an admin to assign the card (members will see a "Contact Us" button instead). Only applies if
+    "REQUIRE_ACCESS_CARD" is `True`.
   * "COLLECT_VEHICLE_REGISTRATION_PLATE" - Allow the portal to collect vehicle registration plate number(s).
 
 ### Canvas Integration

--- a/memberportal/api_general/views.py
+++ b/memberportal/api_general/views.py
@@ -48,6 +48,7 @@ class GetConfig(APIView):
             "signup": {
                 "inductionLink": config.INDUCTION_ENROL_LINK,
                 "requireAccessCard": config.REQUIRE_ACCESS_CARD,
+                "memberCanEnterAccessCard": config.MEMBER_CAN_ENTER_ACCESS_CARD,
                 "postInductionUrl": config.POST_INDUCTION_URL,
                 "collectVehicleRegistrationPlate": config.COLLECT_VEHICLE_REGISTRATION_PLATE,
             },

--- a/memberportal/membermatters/constance_config.py
+++ b/memberportal/membermatters/constance_config.py
@@ -46,7 +46,7 @@ CONSTANCE_CONFIG = {
     "POST_INDUCTION_URL": (
         "https://eventbrite.com.au",
         "The URL members should visit to book in for a site induction after finishing the online induction."
-        " (displayed during signup if REQUIRE_ACCESS_CARD == False)",
+        " (displayed during signup if REQUIRE_ACCESS_CARD == True and MEMBER_CAN_ENTER_ACCESS_CARD == False)",
     ),
     # Logo and favicon
     "SITE_LOGO": (
@@ -310,6 +310,10 @@ CONSTANCE_CONFIG = {
         True,
         "If an access card is required to be added to a members profile before signup.",
     ),
+    "MEMBER_CAN_ENTER_ACCESS_CARD": (
+        True,
+        "If true, members can enter their own RFID card during signup. If false, they will be prompted to contact an admin (displayed during signup if REQUIRE_ACCESS_CARD == True).",
+    ),
     "COLLECT_VEHICLE_REGISTRATION_PLATE": (
         False,
         "Display a field that collects the member's vehicle registration plate on signup & in the profile page.",
@@ -439,6 +443,7 @@ CONSTANCE_CONFIG_FIELDSETS = OrderedDict(
                 "MAX_INDUCTION_DAYS",
                 "MIN_INDUCTION_SCORE",
                 "REQUIRE_ACCESS_CARD",
+                "MEMBER_CAN_ENTER_ACCESS_CARD",
                 "COLLECT_VEHICLE_REGISTRATION_PLATE",
             ),
         ),

--- a/memberportal/profile/models.py
+++ b/memberportal/profile/models.py
@@ -646,8 +646,8 @@ class Profile(ExportModelOperationsMixin("profile"), models.Model):
             ):
                 required_steps.append("induction")
 
-        # check if they have an RFID card assigned
-        if not self.rfid:
+        # check if they have an RFID card assigned (only if required by config)
+        if config.REQUIRE_ACCESS_CARD and not self.rfid:
             required_steps.append("accessCard")
 
         if len(required_steps):

--- a/src-frontend/src/components/Billing/SignupRequiredSteps.vue
+++ b/src-frontend/src/components/Billing/SignupRequiredSteps.vue
@@ -95,7 +95,7 @@
           {{ $tc('signup.assignAccessCard') }}
         </div>
 
-        <template v-if="features.signup.requireAccessCard">
+        <template v-if="features.signup.memberCanEnterAccessCard">
           <div class="row items-stretch">
             <div style="width: 100%">
               <p>
@@ -274,7 +274,9 @@ export default defineComponent({
     },
     inductionCompleted() {
       this.step++;
-      if (this.accessCardComplete) this.step++;
+      if (this.accessCardComplete) {
+        this.completeSignup();
+      }
       clearInterval(this.interval);
     },
     async completeSignup() {


### PR DESCRIPTION
This PR changes functionality to allow signing up without entering an RFID card. This PR changes the REQUIRE_ACCESS_CARD behaviour and adds an option MEMBER_CAN_ENTER_ACCESS_CARD in Constance to enable the new behaviour.
The table below shows how the two settings work in this PR:

|REQUIRE_ACCESS_CARD | MEMBER_CAN_ENTER_ACCESS_CARD | Behavior
|-- | -- | --
|True | True | A new member must enter their own RFID card number during signup.
|True | False | A new member is shown the page with the "Contact Us" button linking to the post-induction URL during signup.
|False | N/A | RFID card step is skipped entirely during signup.

With this PR, when REQUIRE_ACCESS_CARD==true, MEMBER_CAN_ENTER_ACCESS_CARD has the same behaviour as the current system (using REQUIRE_ACCESS_CARD).

Some makerspaces (like ours in Linköping, Sweden) use other access methods than tags, so no tags should be required to sign up.

The code is written in Claude because I do not have much experience in web development. The approach appears sound, but someone else should confirm its validity. I have, of course, reviewed the produced code and tested it to the best of my abilities in a local installation with positive results. 